### PR TITLE
Fixed ``OverflowError`` due to bad batch_size in ``SplitIterator``

### DIFF
--- a/kglm/data/iterators/split_iterator.py
+++ b/kglm/data/iterators/split_iterator.py
@@ -268,4 +268,4 @@ class SplitIterator(BucketIterator):
             self._epochs[key] = epoch + 1
 
     def get_num_batches(self, instances: Iterable[Instance]) -> float:
-        return float("inf")
+        return 1


### PR DESCRIPTION
Since batch_sizes are unknown with random splits we chose infinity
as the default. Turns out this was a bad idea...