### PR TITLE
Awd investigation

### DIFF
--- a/experiments/awd-lstm-lm-modified.jsonnet
+++ b/experiments/awd-lstm-lm-modified.jsonnet
@@ -1,0 +1,37 @@
+{
+    "vocabulary": {
+        "type": "extended",
+        "min_count": {"tokens": 3}
+    },
+    "dataset_reader": {
+        "type": "enhanced-wikitext"
+    },
+    "train_data_path": "./data/mini.train.jsonl",
+    "validation_data_path": "./data/final.valid.jsonl",
+    "model": {
+        "type": "awd-lstm-lm",
+        "embedding_size": 400,
+        "hidden_size": 1150,
+        "num_layers": 3,
+        "tie_weights": true,
+        "dropouth": 0.2,
+        "initializer": [
+            ["embedder.weight", {"type": "uniform", "a": -0.1, "b": 0.1}]
+        ]
+    },
+    "iterator": {
+        "type": "awd",
+        "batch_size": 80,
+        "split_size": 70,
+    },
+    "trainer": {
+        "num_epochs": 500,
+        "cuda_device": 0,
+        "optimizer": {
+            "type": "adam",
+            "lr": 3e-4,
+        },
+        "patience": 10,
+        "validation_metric": "-ppl"
+    }
+}

--- a/experiments/awd-lstm-lm-simple.jsonnet
+++ b/experiments/awd-lstm-lm-simple.jsonnet
@@ -1,14 +1,14 @@
 {
-    "vocabulary": {
-        "type": "extended",
-        "min_count": {"tokens": 3}
-    },
     "dataset_reader": {
-        "type": "enhanced-wikitext"
+        "type": "language_modeling",
+        "tokens_per_instance": 80,
+        "tokenizer": {
+            "type": "word",
+            "word_splitter": {"type": "just_spaces"},
+        },
     },
-    "train_data_path": "./data/mini.train.jsonl",
-    "validation_data_path": "./data/final.valid.jsonl",
-    "datasets_for_vocab_creation": ["train"],
+    "train_data_path": "../awd-lstm-lm/data/enhanced-wikitext/train.txt",
+    "validation_data_path": "../awd-lstm-lm/data/enhanced-wikitext/valid.txt",
     "model": {
         "type": "awd-lstm-lm",
         "embedding_size": 400,
@@ -21,17 +21,16 @@
         ]
     },
     "iterator": {
-        "type": "fancy",
-        "batch_size": 80,
-        "split_size": 70,
+        "type": "basic",
+        "batch_size": 60,
     },
     "trainer": {
         "num_epochs": 500,
-        "cuda_device": 0,
+        "cuda_device": 1,
         "grad_clipping": 0.25,
         "optimizer": {
             "type": "sgd",
-            "lr": 30.0,
+            "lr": 30,
             "weight_decay": 1.2e-6
         },
         "patience": 10,

--- a/experiments/awd-lstm-lm.jsonnet
+++ b/experiments/awd-lstm-lm.jsonnet
@@ -1,0 +1,44 @@
+{
+    "vocabulary": {
+        "type": "extended",
+        "min_count": {"tokens": 3}
+    },
+    "dataset_reader": {
+        "type": "enhanced-wikitext"
+    },
+    "train_data_path": "./data/mini.train.jsonl",
+    "validation_data_path": "./data/final.valid.jsonl",
+    "model": {
+        "type": "awd-lstm-lm",
+        "embedding_size": 400,
+        "hidden_size": 1150,
+        "num_layers": 3,
+        "tie_weights": true,
+        "dropouth": 0.2,
+        "initializer": [
+            ["embedder.weight", {"type": "uniform", "a": -0.1, "b": 0.1}]
+        ]
+    },
+    "iterator": {
+        "type": "split",
+        "batch_size": 80,
+        "splitter": {
+            "type": "random",
+            "mean_split_size": 70,
+            "max_split_size": 80,
+            "min_split_size": 60,
+            "splitting_keys": ["tokens"]
+        },
+        "sorting_keys": [["tokens", "num_tokens"]]
+    },
+    "trainer": {
+        "num_epochs": 500,
+        "cuda_device": 0,
+        "optimizer": {
+            "type": "adam",
+            "lr": 3e-4,
+        },
+        "patience": 10,
+        "validation_metric": "-ppl"
+    }
+}

--- a/experiments/awd-lstm-lm.jsonnet
+++ b/experiments/awd-lstm-lm.jsonnet
@@ -8,6 +8,7 @@
     },
     "train_data_path": "./data/mini.train.jsonl",
     "validation_data_path": "./data/final.valid.jsonl",
+    "datasets_for_vocab_creation": ["train"],
     "model": {
         "type": "awd-lstm-lm",
         "embedding_size": 400,
@@ -20,13 +21,17 @@
         ]
     },
     "iterator": {
-        "type": "split",
+        "type": "fancy",
         "batch_size": 80,
+        "split_size": 70,
+        "splitting_keys": ["tokens"]
+    },
+    "validation_iterator": {
+        "type": "split",
+        "batch_size": 10,
         "splitter": {
-            "type": "random",
-            "mean_split_size": 70,
-            "max_split_size": 80,
-            "min_split_size": 60,
+            "type": "fixed",
+            "split_size": 70,
             "splitting_keys": ["tokens"]
         },
         "sorting_keys": [["tokens", "num_tokens"]]
@@ -34,9 +39,11 @@
     "trainer": {
         "num_epochs": 500,
         "cuda_device": 0,
+        "grad_clipping": 0.25,
         "optimizer": {
-            "type": "adam",
-            "lr": 3e-4,
+            "type": "sgd",
+            "lr": 30.0,
+            "weight_decay": 1.2e-6
         },
         "patience": 10,
         "validation_metric": "-ppl"

--- a/experiments/entity_disc.jsonnet
+++ b/experiments/entity_disc.jsonnet
@@ -1,0 +1,64 @@
+{
+    "vocabulary": {
+        "type": "extended",
+        "extend": false,
+        "directory_path": "./results/entity-nlm-wt2.fixed-vocab.dropout.2/vocabulary"
+    },
+    "dataset_reader": {
+        "type": "enhanced-wikitext",
+        "enumerate_entities": true,
+    },
+    "train_data_path": "data/mini.train.jsonl",
+    "validation_data_path": "data/final.valid.jsonl",
+    "datasets_for_vocab_creation": ["train"],
+    "model": {
+        "type": "entitydisc",
+        "text_field_embedder": {
+            "token_embedders": {
+                "tokens": {
+                    "type": "embedding",
+                    "embedding_dim": 500,
+                    "trainable": true
+                },
+            },
+        },
+        "encoder": {
+            "type": "lstm",
+            "input_size": 500,
+            "hidden_size": 500,
+            "dropout": 0.5,
+            "stateful": true
+        },
+        "embedding_dim": 500,
+        "max_mention_length": 166,
+        "max_embeddings": 1345,
+        "dropout_rate": 0.4,
+        "variational_dropout_rate": 0.1
+    },
+    "iterator": {
+        "type": "split",
+        "batch_size": 60,
+        "splitter": {
+            "type": "random",
+            "mean_split_size": 70,
+            "min_split_size": 30,
+            "max_split_size": 100,
+            "splitting_keys": [
+                "tokens",
+                "entity_types",
+                "entity_ids",
+                "mention_lengths"
+            ],
+        },
+        "sorting_keys": [["tokens", "num_tokens"]],
+    },
+    "trainer": {
+        "num_epochs": 40,
+        "cuda_device": 0,
+        "optimizer": {
+            "type": "adam",
+            "lr": 1e-3
+        },
+        "patience": 10
+    }
+}

--- a/experiments/entity_nlm.jsonnet
+++ b/experiments/entity_nlm.jsonnet
@@ -1,0 +1,72 @@
+{
+    "vocabulary": {
+        "type": "extended",
+        "max_vocab_size": {"tokens": 33278},
+        "min_count": {"tokens": 3},
+    },
+    "dataset_reader": {
+        "type": "enhanced-wikitext",
+        "enumerate_entities": true,
+    },
+    "train_data_path": "data/mini.train.jsonl",
+    "validation_data_path": "data/final.valid.jsonl",
+    "datasets_for_vocab_creation": ["train"],
+    "model": {
+        "type": "entitynlm",
+        "text_field_embedder": {
+            "token_embedders": {
+                "tokens": {
+                    "type": "embedding",
+                    "embedding_dim": 256,
+                    "trainable": true
+                },
+            },
+        },
+        "encoder": {
+            "type": "lstm",
+            "input_size": 256,
+            "hidden_size": 256,
+            "dropout": 0.5,
+            "stateful": true
+        },
+        "embedding_dim": 256,
+        "max_mention_length": 166,
+        "max_embeddings": 1345,
+        "tie_weights": true,
+        "dropout_rate": 0.4,
+        "variational_dropout_rate": 0.1
+    },
+    "iterator": {
+        "type": "split",
+        "batch_size": 40,
+        "splitter": {
+            "type": "random",
+            "mean_split_size": 70,
+            "min_split_size": 30,
+            "max_split_size": 100,
+            "splitting_keys": [
+                "tokens",
+                "entity_types",
+                "entity_ids",
+                "mention_lengths"
+            ],
+        },
+        "sorting_keys": [["tokens", "num_tokens"]],
+    },
+    "trainer": {
+        "num_epochs": 500,
+        "cuda_device": 1,
+        "optimizer": {
+            "type": "adam",
+            "lr": 1e-3
+        },
+        "learning_rate_scheduler": {
+            "type": "reduce_on_plateau",
+            "mode": "max",
+            "min_lr": 1e-6
+        },
+        "patience": 20,
+        "validation_metric": "-ppl",
+        "should_log_learning_rate": true
+    }
+}

--- a/experiments/kglm.jsonnet
+++ b/experiments/kglm.jsonnet
@@ -1,0 +1,81 @@
+{
+    "vocabulary": {
+        "type": "extended",
+        "min_count": {"tokens": 3},
+        "pretrained_files": {
+            "entity_ids": "data/mini.embeddings.400.txt"
+        }
+    },
+    "dataset_reader": {
+        "type": "enhanced-wikitext-kglm",
+        "alias_database_path": "data/mini.alias.pkl"
+    },
+    "train_data_path": "data/mini.train.jsonl",
+    "validation_data_path": "data/final.valid.jsonl",
+    "datasets_for_vocab_creation": ["train"],
+    "model": {
+        "type": "kglm",
+        "token_embedder": {
+            "token_embedders": {
+                "tokens": {
+                    "type": "embedding",
+                    "embedding_dim": 400,
+                    "trainable": true
+                }
+            }
+        },
+        "entity_embedder": {
+            "token_embedders": {
+                "entity_ids": {
+                    "type": "embedding",
+                    "pretrained_file": "data/mini.embeddings.400.txt",
+                    "embedding_dim": 400,
+                    "trainable": false,
+                    "vocab_namespace": "entity_ids"
+                }
+            }
+        },
+        "encoder": {
+            "type": "lstm",
+            "input_size": 400,
+            "hidden_size": 400,
+            "num_layers": 1,
+            "stateful": true
+        },
+        "tie_weights": true,
+        "dropout_rate": 0.6,
+        "variational_dropout_rate": 0.3
+    },
+    "iterator": {
+        "type": "split",
+        "batch_size": 24,
+        "splitter": {
+            "type": "random",
+            "mean_split_size": 70,
+            "min_split_size": 60,
+            "max_split_size": 80,
+            "splitting_keys": [
+                "tokens",
+                "entity_identifiers",
+                "shortlist_indices",
+                "alias_copy_indices"
+            ]
+        },
+        "sorting_keys": [["tokens", "num_tokens"]],
+    },
+    "trainer": {
+        "cuda_device": 0,
+        "num_epochs": 500,
+        "optimizer": {
+            "type": "adam",
+            "lr": 1e-3,
+            "betas": [0.0, 0.999], // State of art of evaluation LMs
+        },
+        "learning_rate_scheduler": {
+            "type": "reduce_on_plateau",
+            "factor": 0.1,
+            "patience": 3
+        },
+        "patience": 10
+    }
+}

--- a/kglm/data/dataset_readers/enhanced_wikitext.py
+++ b/kglm/data/dataset_readers/enhanced_wikitext.py
@@ -50,8 +50,12 @@ class EnhancedWikitextReader(DatasetReader):
         tokens = _flatten(data['tokens'])
         tokens = ['@@START@@', *tokens, '@@END@@']
         tokens = [Token(x) for x in tokens]
-        fields = {'tokens': TextField(tokens, self._token_indexers)}
-
+        source = tokens[:-1]
+        target = tokens[1:]
+        fields = {
+                'source': TextField(source, self._token_indexers),
+                'target': TextField(target, self._token_indexers)
+        }
         return Instance(fields)
 
 

--- a/kglm/data/fields/sequential_array.py
+++ b/kglm/data/fields/sequential_array.py
@@ -30,7 +30,7 @@ class SequentialArrayField(ArrayField, SequenceField):
                      for i in range(len(padding_lengths))]
 
         # Convert explicitly to an ndarray just in case it's an scalar (it'd end up not being an ndarray otherwise)
-        return_array = np.asarray(np.ones(max_shape, self._dtype) * self.padding_value)
+        return_array = np.asarray(np.full(max_shape, self.padding_value), dtype=self._dtype)
 
         # If the tensor has a different shape from the largest tensor, pad dimensions with zeros to
         # form the right shaped list of slices for insertion into the final tensor.

--- a/kglm/data/iterators/__init__.py
+++ b/kglm/data/iterators/__init__.py
@@ -1,2 +1,3 @@
-from .split_iterator import Splitter, SplitIterator
+from .awd_iterator import AwdIterator
 from .fancy_iterator import FancyIterator
+from .split_iterator import Splitter, SplitIterator

--- a/kglm/data/iterators/__init__.py
+++ b/kglm/data/iterators/__init__.py
@@ -1,1 +1,2 @@
 from .split_iterator import Splitter, SplitIterator
+from .fancy_iterator import FancyIterator

--- a/kglm/data/iterators/awd_iterator.py
+++ b/kglm/data/iterators/awd_iterator.py
@@ -49,12 +49,17 @@ class AwdIterator(DataIterator):
             instance_list = list(instances)
             if shuffle:
                 random.shuffle(instance_list)
+            for instance in instance_list:
+                instance.index_fields(self.vocab)
             tensor_dicts = [instance.as_tensor_dict() for instance in instance_list]
             tokens = [d['tokens']['tokens'] for d in tensor_dicts]
             omni_tensor = torch.cat(tokens, 0)
+            truncate_to = self._batch_size * (omni_tensor.shape[0] // self._batch_size)
+            omni_tensor = omni_tensor[:truncate_to]
             omni_tensor = omni_tensor.view(self._batch_size, -1)
             split_indices = list(range(0, omni_tensor.shape[1], self._split_size))
             for start, end in zip(split_indices[:-1], split_indices[1:]):
                 yield {'tokens': omni_tensor[:, start:end]}
 
             self._epochs[key] = epoch + 1
+

--- a/kglm/data/iterators/awd_iterator.py
+++ b/kglm/data/iterators/awd_iterator.py
@@ -1,0 +1,60 @@
+import logging
+import itertools
+import random
+from typing import Dict, Iterable, Iterator, List, Tuple, Union
+
+from allennlp.data.instance import Instance
+from allennlp.data.iterators import DataIterator
+import torch
+
+logger = logging.getLogger(__name__)
+
+TensorDict = Dict[str, Union[torch.Tensor, Dict[str, torch.Tensor]]]  # pylint: disable=invalid-name
+
+
+@DataIterator.register('awd')
+class AwdIterator(DataIterator):
+    def __init__(self,
+                 split_size: int,
+                 batch_size: int = 32,
+                 instances_per_epoch: int = None,
+                 max_instances_in_memory: int = None,
+                 cache_instances: bool = False,
+                 track_epoch: bool = False,
+                 maximum_samples_per_batch: Tuple[str, int] = None) -> None:
+        super(AwdIterator, self).__init__(
+                batch_size=batch_size,
+                instances_per_epoch=instances_per_epoch,
+                max_instances_in_memory=max_instances_in_memory,
+                cache_instances=cache_instances,
+                track_epoch=track_epoch,
+                maximum_samples_per_batch=maximum_samples_per_batch)
+        self._split_size = split_size
+
+    def __call__(self,
+                 instances: Iterable[Instance],
+                 num_epochs: int = None,
+                 shuffle: bool = False) -> Iterator[TensorDict]:
+        key = id(instances)
+        starting_epoch = self._epochs[key]
+
+        if num_epochs is None:
+            epochs: Iterable[int] = itertools.count(starting_epoch)
+        else:
+            epochs = range(starting_epoch, starting_epoch + num_epochs)
+
+        for epoch in epochs:
+            # In order to ensure that we are (almost) constantly streaming data to the model we
+            # need to have all of the instances in memory ($$$)
+            instance_list = list(instances)
+            if shuffle:
+                random.shuffle(instance_list)
+            tensor_dicts = [instance.as_tensor_dict() for instance in instance_list]
+            tokens = [d['tokens']['tokens'] for d in tensor_dicts]
+            omni_tensor = torch.cat(tokens, 0)
+            omni_tensor = omni_tensor.view(self._batch_size, -1)
+            split_indices = list(range(0, omni_tensor.shape[1], self._split_size))
+            for start, end in zip(split_indices[:-1], split_indices[1:]):
+                yield {'tokens': omni_tensor[:, start:end]}
+
+            self._epochs[key] = epoch + 1

--- a/kglm/data/iterators/fancy_iterator.py
+++ b/kglm/data/iterators/fancy_iterator.py
@@ -1,0 +1,144 @@
+from collections import deque
+import logging
+import itertools
+import random
+from typing import Deque, Dict, Iterable, Iterator, List, Tuple, Union
+
+from allennlp.data.dataset import Batch
+from allennlp.data.fields import TextField
+from allennlp.data.instance import Instance
+from allennlp.data.iterators.data_iterator import add_epoch_number, DataIterator
+import numpy as np
+import torch
+
+from kglm.data.fields import SequentialArrayField
+
+logger = logging.getLogger(__name__)
+
+TensorDict = Dict[str, Union[torch.Tensor, Dict[str, torch.Tensor]]]  # pylint: disable=invalid-name
+
+
+@DataIterator.register('fancy')
+class FancyIterator(DataIterator):
+    """Fancy cause it's really expensive."""
+    def __init__(self,
+                 splitting_keys: List[str],
+                 split_size: int,
+                 batch_size: int = 32,
+                 instances_per_epoch: int = None,
+                 max_instances_in_memory: int = None,
+                 cache_instances: bool = False,
+                 track_epoch: bool = False,
+                 maximum_samples_per_batch: Tuple[str, int] = None) -> None:
+        super(FancyIterator, self).__init__(
+                batch_size=batch_size,
+                instances_per_epoch=instances_per_epoch,
+                max_instances_in_memory=max_instances_in_memory,
+                cache_instances=cache_instances,
+                track_epoch=track_epoch,
+                maximum_samples_per_batch=maximum_samples_per_batch)
+        self._splitting_keys = splitting_keys
+        self._split_size = split_size
+
+    def __call__(self,
+                 instances: Iterable[Instance],
+                 num_epochs: int = None,
+                 shuffle: bool = False) -> Iterator[TensorDict]:
+        key = id(instances)
+        starting_epoch = self._epochs[key]
+
+        if num_epochs is None:
+            epochs: Iterable[int] = itertools.count(starting_epoch)
+        else:
+            epochs = range(starting_epoch, starting_epoch + num_epochs)
+
+        for epoch in epochs:
+
+            # In order to ensure that we are (almost) constantly streaming data to the model we
+            # need to have all of the instances in memory ($$$)
+            instance_list = list(instances)
+            if shuffle:
+                random.shuffle(instance_list)
+
+            # We create queues for each instance in the batch, and greedily fill them to try and
+            # ensure each queue's length is roughly equal in size.
+            queues: List[Deque[Instance]] = [deque() for _ in range(self._batch_size)]
+            queue_lengths = np.zeros(self._batch_size, dtype=int)
+            for instance in instances:
+
+                # Now we split the instance into chunks.
+                chunks, length = self._split(instance)
+
+                # Next we identify which queue is the shortest and add the chunks to that queue.
+                destination = np.argmin(queue_lengths)
+                queues[destination].extend(chunks)
+                queue_lengths[destination] += length
+
+            for batch in self._generate_batches(queues):
+                if self._track_epoch:
+                    add_epoch_number(batch, epoch)
+
+                if self.vocab is not None:
+                    batch.index_instances(self.vocab)
+
+                padding_lengths = batch.get_padding_lengths()
+                yield batch.as_tensor_dict(padding_lengths)
+
+            self._epochs[key] = epoch + 1
+
+    def _split(self, instance: Instance) -> Tuple[List[Instance], int]:
+        # Determine the size of the sequence inside the instance.
+        true_length = len(instance['tokens'])
+        padded_length = self._split_size * (true_length // self._split_size)
+
+        # Determine the split indices.
+        split_indices = list(range(0, true_length, self._split_size))
+        if true_length > split_indices[-1]:
+            split_indices.append(true_length)
+
+        # Determine which fields are not going to be split
+        constant_fields = [x for x in instance.fields if x not in self._splitting_keys]
+
+        # Create the list of chunks
+        chunks: List[Instance] = []
+
+        for i, (start, end) in enumerate(zip(split_indices[:-1], split_indices[1:])):
+
+            # Copy all of the constant fields from the instance to the chunk.
+            chunk_fields = {key: instance[key] for key in constant_fields}
+
+            # Determine whether or not to signal model to reset.
+            if i == 0:
+                reset = SequentialArrayField(np.array(1, dtype=np.uint8), dtype=np.uint8)
+            else:
+                reset = SequentialArrayField(np.array(0, dtype=np.uint8), dtype=np.uint8)
+            chunk_fields['reset'] = reset
+
+            # Obtain splits derived from sequence fields.
+            for key in self._splitting_keys:
+                source_field = instance[key]
+                # pylint: disable=protected-access
+                if isinstance(source_field, TextField):
+                    split_field = TextField(source_field.tokens[start:end],
+                                            source_field._token_indexers)
+                elif isinstance(source_field, SequentialArrayField):
+                    # TODO: Figure out how to use sequence dim here...
+                    split_field = SequentialArrayField(source_field.array[start:end],
+                                                       dtype=source_field._dtype)
+                else:
+                    raise NotImplementedError('FancyIterator currently only supports splitting '
+                                              '`TextField`s or `SequentialArrayField`s.')
+                chunk_fields[key] = split_field
+            chunks.append(Instance(chunk_fields))
+
+        return chunks, padded_length
+
+    @staticmethod
+    def _generate_batches(queues: List[Deque[Instance]]) -> Iterator[Batch]:
+        while True:
+            try:
+                instances = [q.popleft() for q in queues]
+            except IndexError:
+                break
+            batch = Batch(instances)
+            yield batch

--- a/kglm/data/iterators/fancy_iterator.py
+++ b/kglm/data/iterators/fancy_iterator.py
@@ -88,7 +88,7 @@ class FancyIterator(DataIterator):
 
     def _split(self, instance: Instance) -> Tuple[List[Instance], int]:
         # Determine the size of the sequence inside the instance.
-        true_length = len(instance['tokens'])
+        true_length = len(instance['source'])
         padded_length = self._split_size * (true_length // self._split_size)
 
         # Determine the split indices.
@@ -109,9 +109,9 @@ class FancyIterator(DataIterator):
 
             # Determine whether or not to signal model to reset.
             if i == 0:
-                reset = SequentialArrayField(np.array(1, dtype=np.uint8), dtype=np.uint8)
+                reset = SequentialArrayField(np.array(1), dtype=np.uint8)
             else:
-                reset = SequentialArrayField(np.array(0, dtype=np.uint8), dtype=np.uint8)
+                reset = SequentialArrayField(np.array(0), dtype=np.uint8)
             chunk_fields['reset'] = reset
 
             # Obtain splits derived from sequence fields.
@@ -145,4 +145,3 @@ class FancyIterator(DataIterator):
 
     def get_num_batches(self, instances: Iterable[Instance]) -> float:
         return 1
-

--- a/kglm/data/iterators/fancy_iterator.py
+++ b/kglm/data/iterators/fancy_iterator.py
@@ -142,3 +142,7 @@ class FancyIterator(DataIterator):
                 break
             batch = Batch(instances)
             yield batch
+
+    def get_num_batches(self, instances: Iterable[Instance]) -> float:
+        return 1
+

--- a/kglm/data/iterators/split_iterator.py
+++ b/kglm/data/iterators/split_iterator.py
@@ -41,13 +41,13 @@ class Splitter(Registrable):
     def __init__(self, splitting_keys: List[str]) -> None:
         self._splitting_keys = splitting_keys
 
-    def __call__(self, tensor_dict: TensorDict) -> Iterable[TensorDict]:
+    def __call__(self, tensor_dict: TensorDict, truncate_at: int) -> Iterable[TensorDict]:
 
         if not all(key in tensor_dict for key in self._splitting_keys):
             missing_keys = [key for key in self._splitting_keys if key not in tensor_dict]
             raise RuntimeError('Tensor dict is missing splitting keys: %s' % missing_keys)
 
-        sequence_length = self._get_sequence_length(tensor_dict)
+        sequence_length = truncate_at
 
         split_indices = self._create_split_indices(sequence_length)
         # If the last split is too small, then merge with the second to last
@@ -253,15 +253,23 @@ class SplitIterator(BucketIterator):
                     if self.vocab is not None:
                         batch.index_instances(self.vocab)
 
+
+                    # In order to make  gradient updates fair in expectation,
+                    # we randomly choose a sequence to cutoff at.
+                    all_instance_lengths = [instance.get_padding_lengths() for
+                                            instance in batch.instances]
+                    random_instance = random.choice(all_instance_lengths)
+                    truncate_at = random_instance['tokens']['num_tokens']
                     padding_lengths = batch.get_padding_lengths()
-                    logger.debug("Batch padding lengths: %s", str(padding_lengths))
-                    logger.debug("Batch size: %d", len(batch.instances))
+                    logger.debug('trunacate at: %s', truncate_at)
+                    logger.debug('padding_lengths: %s', padding_lengths)
+
                     tensor_dict = batch.as_tensor_dict(padding_lengths)
 
                     if add_to_cache:
                         self._cache[key].append(tensor_dict)
 
-                    for split_tensor_dict in self._splitter(tensor_dict):
+                    for split_tensor_dict in self._splitter(tensor_dict, truncate_at):
                         yield split_tensor_dict
 
             # Increment epoch tracker
@@ -269,3 +277,4 @@ class SplitIterator(BucketIterator):
 
     def get_num_batches(self, instances: Iterable[Instance]) -> float:
         return 1
+

--- a/kglm/data/iterators/split_iterator.py
+++ b/kglm/data/iterators/split_iterator.py
@@ -277,4 +277,3 @@ class SplitIterator(BucketIterator):
 
     def get_num_batches(self, instances: Iterable[Instance]) -> float:
         return 1
-

--- a/kglm/models/awd_lstm.py
+++ b/kglm/models/awd_lstm.py
@@ -120,15 +120,14 @@ class AwdLstmLanguageModel(Model):
 
     @overrides
     def forward(self,  # pylint: disable=arguments-differ
-                tokens: Dict[str, torch.Tensor],
-                reset: torch.Tensor) -> Dict[str, torch.Tensor]:
+                tokens: Dict[str, torch.Tensor]) -> Dict[str, torch.Tensor]:  # ,
+                # reset: torch.Tensor) -> Dict[str, torch.Tensor]:
 
 
         # TODO: Update for array reset
         # Reset the model if needed
         # if reset:
         #     self._state = None
-        import pdb; pdb.set_trace()
 
         token_tensor = tokens['tokens']
         if self._state is not None:
@@ -181,7 +180,7 @@ class AwdLstmLanguageModel(Model):
 
         # Update previous hidden state
         self._state = {
-                'tokens': token_tensor[:, -1].unsqueeze(1)
+                # 'tokens': token_tensor[:, -1].unsqueeze(1)
         }
         for layer, hidden in enumerate(current_hidden):
             self._state['layer_%i' % layer] = hidden

--- a/kglm/models/awd_lstm.py
+++ b/kglm/models/awd_lstm.py
@@ -121,11 +121,14 @@ class AwdLstmLanguageModel(Model):
     @overrides
     def forward(self,  # pylint: disable=arguments-differ
                 tokens: Dict[str, torch.Tensor],
-                reset: bool) -> Dict[str, torch.Tensor]:
+                reset: torch.Tensor) -> Dict[str, torch.Tensor]:
 
+
+        # TODO: Update for array reset
         # Reset the model if needed
-        if reset:
-            self._state = None
+        # if reset:
+        #     self._state = None
+        import pdb; pdb.set_trace()
 
         token_tensor = tokens['tokens']
         if self._state is not None:

--- a/kglm/models/awd_lstm.py
+++ b/kglm/models/awd_lstm.py
@@ -7,14 +7,16 @@ from allennlp.data.vocabulary import Vocabulary #, DEFAULT_OOV_TOKEN
 from allennlp.models import Model
 from allennlp.nn import InitializerApplicator
 # from allennlp.nn.util import get_text_field_mask, masked_log_softmax
-from allennlp.training.metrics import Average
+from allennlp.nn.util import sequence_cross_entropy_with_logits
+# from allennlp.training.metrics import Average
 from overrides import overrides
 import torch
 # import torch.nn.functional as F
 
-# from kglm.common.typing import StateDict
+from kglm.common.typing import StateDict
 # from kglm.data import AliasDatabase
 from kglm.modules import embedded_dropout, LockedDropout, SplitCrossEntropyLoss # , WeightDrop
+from kglm.training.metrics import Ppl
 
 logger = logging.getLogger(__name__)
 
@@ -51,11 +53,11 @@ class AwdLstmLanguageModel(Model):
                  hidden_size: int,
                  num_layers: int,
                  splits: List[int] = [],
-                 dropout: float = 0.5,
-                 dropouth: float = 0.5,
-                 dropouti: float = 0.5,
+                 dropout: float = 0.4,
+                 dropouth: float = 0.3,
+                 dropouti: float = 0.65,
                  dropoute: float = 0.1,
-                 wdrop: float = 0.0,
+                 wdrop: float = 0.5,
                  alpha: float = 2.0,
                  beta: float = 1.0,
                  tie_weights: bool = False,
@@ -79,7 +81,7 @@ class AwdLstmLanguageModel(Model):
         self.dropout = dropout
 
         # Initialize empty state dict
-        self._state: Optional[List[torch.Tensor]] = None
+        self._state: StateDict = None
 
         # Tokens are manually embedded instead of using a TokenEmbedder to make using
         # embedding_dropout easier.
@@ -105,14 +107,14 @@ class AwdLstmLanguageModel(Model):
 
         self.decoder = torch.nn.Linear(hidden_size, vocab.get_vocab_size(namespace='tokens'))
 
-        self.criterion = SplitCrossEntropyLoss(embedding_size, splits=splits, verbose=False)
+        # self.criterion = SplitCrossEntropyLoss(embedding_size, splits=splits, verbose=False)
 
         # Optionally tie weights
         if tie_weights:
             # pylint: disable=protected-access
-            self.decoder.weight = self.text_field_embedder._token_embedder.weight
+            self.decoder.weight = self.embedder.weight
 
-        self._avg_vocab_loss = Average()
+        self.ppl = Ppl()
 
         initializer(self)
 
@@ -125,13 +127,13 @@ class AwdLstmLanguageModel(Model):
         if reset:
             self._state = None
 
-        # Easier to work with tokens this way
         token_tensor = tokens['tokens']
+        if self._state is not None:
+            prev_token = self._state['tokens']
+            token_tensor = torch.cat((prev_token, token_tensor), dim=1)
         inputs = token_tensor[:, :-1].contiguous()
         targets = token_tensor[:, 1:].contiguous()
         target_masks = targets.gt(0)
-        if target_masks.float().sum() == 0.0:
-            print('WTF')
 
         embeddings = embedded_dropout(self.embedder, inputs,
                                       dropout=self.dropoute if self.training else 0)
@@ -143,7 +145,7 @@ class AwdLstmLanguageModel(Model):
         dropped_outputs = []
         for layer, rnn in enumerate(self.rnns):
             if self._state is not None:
-                prev_hidden = self._state[layer]
+                prev_hidden = self._state['layer_%i' % layer]
             else:
                 prev_hidden = None
             output, hidden = rnn(current_input, prev_hidden)
@@ -161,24 +163,29 @@ class AwdLstmLanguageModel(Model):
                 current_input = self.locked_dropout(output, self.dropouth)
                 dropped_outputs.append(current_input)
 
-        self._state = current_hidden
+        logits = self.decoder(output)
+        loss = sequence_cross_entropy_with_logits(logits, targets,
+                                                  target_masks.float(),
+                                                  average="token")
+        num_tokens = target_masks.float().sum().float()
+        self.ppl(loss * num_tokens, num_tokens)
 
-        loss = self.criterion(self.decoder.weight, self.decoder.bias, output,
-                              targets.view(-1),
-                              target_masks.view(-1))
-        self._avg_vocab_loss(loss)
+        if self.alpha:
+            loss = loss + sum(self.alpha * dropped_rnn_h.pow(2).mean() for dropped_rnn_h in dropped_outputs[-1:])
+        # Temporal Activation Regularization (slowness)
+        if self.beta:
+            loss = loss + sum(self.beta * (rnn_h[1:] - rnn_h[:-1]).pow(2).mean() for rnn_h in outputs[-1:])
 
-        # TODO: Make this work...
-        # # Add regularization terms
-        # if self.alpha:
-        #     loss = loss + sum(self.alpha * dropped_rnn_h.pow(2).mean() for dropped_rnn_h in dropped_outputs[-1:])
-        # # Temporal Activation Regularization (slowness)
-        # if self.beta:
-        #     loss = loss + sum(self.beta * (rnn_h[1:] - rnn_h[:-1]).pow(2).mean() for rnn_h in outputs[-1:])
+        # Update previous hidden state
+        self._state = {
+                'tokens': token_tensor[:, -1].unsqueeze(1)
+        }
+        for layer, hidden in enumerate(current_hidden):
+            self._state['layer_%i' % layer] = hidden
 
         return {'loss': loss}
 
     def get_metrics(self, reset: bool = False) -> Dict[str, float]:
         return {
-                'vocab_loss': self._avg_vocab_loss.get_metric(reset).item()
+            'ppl': self.ppl.get_metric(reset)
         }

--- a/kglm/models/entity_nlm.py
+++ b/kglm/models/entity_nlm.py
@@ -18,7 +18,7 @@ from torch.nn import Parameter
 import torch.nn.functional as F
 
 from kglm.modules import DynamicEmbedding
-from kglm.training.metrics import Perplexity, UnknownPenalizedPerplexity
+# from kglm.training.metrics import Perplexity, UnknownPenalizedPerplexity
 
 logger = logging.getLogger(__name__)
 
@@ -109,17 +109,14 @@ class EntityNLM(Model):
         if tie_weights:
             self._vocab_projection.weight = self._text_field_embedder._token_embedders['tokens'].weight  # pylint: disable=W0212
 
-        self._perplexity = Perplexity()
-        self._unknown_penalized_perplexity = UnknownPenalizedPerplexity(self.vocab)
+        # self._perplexity = Perplexity()
+        # self._unknown_penalized_perplexity = UnknownPenalizedPerplexity(self.vocab)
         self._entity_type_accuracy = CategoricalAccuracy()
         self._entity_id_accuracy = CategoricalAccuracy()
         self._mention_length_accuracy = CategoricalAccuracy()
 
         if tie_weights:
             self._vocab_projection.weight = self._text_field_embedder._token_embedders['tokens'].weight  # pylint: disable=W0212
-
-        self._perplexity = Perplexity()
-        self._unknown_penalized_perplexity = UnknownPenalizedPerplexity(self.vocab)
 
         initializer(self)
 
@@ -359,12 +356,12 @@ class EntityNLM(Model):
             vocab_loss += _vocab_loss.sum()
             logp += -_vocab_loss
 
-            self._perplexity(logits=vocab_logits,
-                             labels=next_tokens,
-                             mask=next_mask.float())
-            self._unknown_penalized_perplexity(logits=vocab_logits,
-                                               labels=next_tokens,
-                                               mask=next_mask.float())
+            # self._perplexity(logits=vocab_logits,
+            #                  labels=next_tokens,
+            #                  mask=next_mask.float())
+            # self._unknown_penalized_perplexity(logits=vocab_logits,
+            #                                    labels=next_tokens,
+            #                                    mask=next_mask.float())
 
             # Lastly update contexts
             contexts = current_hidden
@@ -409,8 +406,8 @@ class EntityNLM(Model):
     @overrides
     def get_metrics(self, reset: bool = False) -> Dict[str, float]:
         return {
-                'ppl': self._perplexity.get_metric(reset),
-                'upp': self._unknown_penalized_perplexity.get_metric(reset),
+                # 'ppl': self._perplexity.get_metric(reset),
+                # 'upp': self._unknown_penalized_perplexity.get_metric(reset),
                 'et_acc': self._entity_type_accuracy.get_metric(reset),
                 'eid_acc': self._entity_id_accuracy.get_metric(reset),
                 'ml_acc': self._mention_length_accuracy.get_metric(reset)

--- a/kglm/modules/splitcross.py
+++ b/kglm/modules/splitcross.py
@@ -24,6 +24,7 @@ class SplitCrossEntropyLoss(nn.Module):
             self.tail_bias = nn.Parameter(torch.zeros(self.nsplits - 1))
 
     def logprob(self, weight, bias, hiddens, splits=None, softmaxed_head_res=None, verbose=False):
+        import pdb; pdb.set_trace()
         # First we perform the first softmax on the head vocabulary and the tombstones
         if softmaxed_head_res is None:
             start, end = self.splits[0], self.splits[1]
@@ -141,10 +142,7 @@ class SplitCrossEntropyLoss(nn.Module):
             # For those targets in the head (idx == 0) we only need to return their loss
             if idx == 0:
                 softmaxed_head_res = softmaxed_all_head_res[running_offset:running_offset + len(split_hiddens[idx])]
-                try:
-                    entropy = -torch.gather(softmaxed_head_res, dim=1, index=split_targets[idx].view(-1, 1))
-                except RuntimeError:
-                    import pdb; pdb.set_trace()
+                entropy = -torch.gather(softmaxed_head_res, dim=1, index=split_targets[idx].view(-1, 1))
                 entropy[split_targets[idx]==0] = 0
             # If the target is in one of the splits, the probability is the p(tombstone) * p(word within tombstone)
             else:

--- a/kglm/modules/weight_drop.py
+++ b/kglm/modules/weight_drop.py
@@ -3,7 +3,26 @@ from torch.nn import Parameter
 from torch.nn.modules.rnn import RNNBase
 from functools import wraps
 
+
+class BackHook(torch.nn.Module):
+    def __init__(self, hook):
+        super(BackHook, self).__init__()
+        self._hook = hook
+        self.register_backward_hook(self._backward)
+
+    def forward(self, *inp):
+        return inp
+
+    @staticmethod
+    def _backward(self, grad_in, grad_out):
+        self._hook()
+        return None
+
+
 class WeightDrop(torch.nn.Module):
+    """
+    Implements drop-connect, as per Merity et al https://arxiv.org/abs/1708.02182
+    """
     def __init__(self, module, weights, dropout=0, variational=False):
         super(WeightDrop, self).__init__()
         self.module = module
@@ -11,13 +30,7 @@ class WeightDrop(torch.nn.Module):
         self.dropout = dropout
         self.variational = variational
         self._setup()
-
-    def widget_demagnetizer_y2k_edition(*args, **kwargs):
-        # We need to replace flatten_parameters with a nothing function
-        # It must be a function rather than a lambda as otherwise pickling explodes
-        # We can't write boring code though, so ... WIDGET DEMAGNETIZER Y2K EDITION!
-        # (╯°□°）╯︵ ┻━┻
-        return
+        self.hooker = BackHook(lambda: self._backward())
 
     def _setup(self):
         for name_w in self.weights:
@@ -28,71 +41,23 @@ class WeightDrop(torch.nn.Module):
     def _setweights(self):
         for name_w in self.weights:
             raw_w = getattr(self, name_w + '_raw')
-            w = None
-            if self.variational:
-                mask = torch.autograd.Variable(torch.ones(raw_w.size(0), 1))
-                if raw_w.is_cuda: mask = mask.cuda()
+            if self.training:
+                mask = raw_w.new_ones((raw_w.size(0), 1))
                 mask = torch.nn.functional.dropout(mask, p=self.dropout, training=True)
                 w = mask.expand_as(raw_w) * raw_w
+                setattr(self, name_w + "_mask", mask)
             else:
-                w = torch.nn.functional.dropout(raw_w, p=self.dropout, training=self.training)
-            self.module._parameters[name_w].data = w
+                w = raw_w
+            rnn_w = getattr(self.module, name_w)
+            rnn_w.data.copy_(w)
+
+    def _backward(self):
+        # transfer gradients from embeddedRNN to raw params
+        for name_w in self.weights:
+            raw_w = getattr(self, name_w + '_raw')
+            rnn_w = getattr(self.module, name_w)
+            raw_w.grad = rnn_w.grad * getattr(self, name_w + "_mask")
 
     def forward(self, *args):
         self._setweights()
-        return self.module.forward(*args)
-
-    def parameters(self, recurse=True):
-        return self.module.parameters(recurse=recurse)
-
-if __name__ == '__main__':
-    import torch
-    from weight_drop import WeightDrop
-
-    # Input is (seq, batch, input)
-    x = torch.autograd.Variable(torch.randn(2, 1, 10)).cuda()
-    h0 = None
-
-    ###
-
-    print('Testing WeightDrop')
-    print('=-=-=-=-=-=-=-=-=-=')
-
-    ###
-
-    print('Testing WeightDrop with Linear')
-
-    lin = WeightDrop(torch.nn.Linear(10, 10), ['weight'], dropout=0.9)
-    lin.cuda()
-    run1 = [x.sum() for x in lin(x).data]
-    run2 = [x.sum() for x in lin(x).data]
-
-    print('All items should be different')
-    print('Run 1:', run1)
-    print('Run 2:', run2)
-
-    assert run1[0] != run2[0]
-    assert run1[1] != run2[1]
-
-    print('---')
-
-    ###
-
-    print('Testing WeightDrop with LSTM')
-
-    wdrnn = WeightDrop(torch.nn.LSTM(10, 10), ['weight_hh_l0'], dropout=0.9)
-    wdrnn.cuda()
-
-    run1 = [x.sum() for x in wdrnn(x, h0)[0].data]
-    run2 = [x.sum() for x in wdrnn(x, h0)[0].data]
-
-    print('First timesteps should be equal, all others should differ')
-    print('Run 1:', run1)
-    print('Run 2:', run2)
-
-    # First time step, not influenced by hidden to hidden weights, should be equal
-    assert run1[0] == run2[0]
-    # Second step should not
-    assert run1[1] != run2[1]
-
-    print('---')
+        return self.module(*self.hooker(*args))

--- a/kglm/tests/data/alias_database_test.py
+++ b/kglm/tests/data/alias_database_test.py
@@ -10,7 +10,7 @@ from kglm.data import AliasDatabase
 
 
 class AliasDatabaseTest(AllenNlpTestCase):
-    # pylint: disable=protected-access
+    # pylint: disable=protected-access,no-self-use
 
     def setUp(self):
         self.token_lookup = {

--- a/kglm/tests/fixtures/training_config/awd-lstm-lm.json
+++ b/kglm/tests/fixtures/training_config/awd-lstm-lm.json
@@ -11,14 +11,10 @@
         "num_layers": 3
     },
     "iterator": {
-        "type": "split",
-        "batch_size": 1,
-        "splitter": {
-            "type": "fixed",
-            "split_size": 50,
-            "splitting_keys": ["tokens"]
-        },
-        "sorting_keys": [["tokens", "num_tokens"]]
+        "type": "fancy",
+        "batch_size": 2,
+        "split_size": 10,
+        "splitting_keys": ["tokens"]
     },
     "trainer": {
         "num_epochs": 2,

--- a/kglm/tests/fixtures/training_config/awd-lstm-lm.json
+++ b/kglm/tests/fixtures/training_config/awd-lstm-lm.json
@@ -14,7 +14,7 @@
         "type": "fancy",
         "batch_size": 2,
         "split_size": 10,
-        "splitting_keys": ["tokens"]
+        "splitting_keys": ["source", "target"]
     },
     "trainer": {
         "num_epochs": 2,

--- a/kglm/tests/fixtures/training_config/awd-lstm-lm.json
+++ b/kglm/tests/fixtures/training_config/awd-lstm-lm.json
@@ -8,7 +8,8 @@
         "type": "awd-lstm-lm",
         "embedding_size": 5,
         "hidden_size": 7,
-        "num_layers": 3
+        "num_layers": 3,
+        "tie_weights": true
     },
     "iterator": {
         "type": "fancy",

--- a/kglm/tests/fixtures/training_config/awd-lstm-lm.json
+++ b/kglm/tests/fixtures/training_config/awd-lstm-lm.json
@@ -12,21 +12,19 @@
     },
     "iterator": {
         "type": "split",
-        "batch_size": 2,
+        "batch_size": 1,
         "splitter": {
             "type": "fixed",
-            "split_size": 10,
+            "split_size": 50,
             "splitting_keys": ["tokens"]
         },
         "sorting_keys": [["tokens", "num_tokens"]]
     },
     "trainer": {
         "num_epochs": 2,
-        "grad_clipping": 0.25,
         "optimizer": {
-            "type": "sgd",
-            "lr": 30.0,
-            "weight_decay": 1.2e-6
+            "type": "adam",
+            "lr": 1e-4
         }
     }
 }

--- a/kglm/tests/fixtures/training_config/entity_nlm.json
+++ b/kglm/tests/fixtures/training_config/entity_nlm.json
@@ -1,0 +1,72 @@
+{
+    "dataset_reader": {
+        "type": "enhanced-wikitext-entity-nlm"
+    },
+    "iterator": {
+        "type": "split",
+        "batch_size": 2,
+        "sorting_keys": [
+            [
+                "tokens",
+                "num_tokens"
+            ]
+        ],
+        "splitter": {
+            "type": "fixed",
+            "split_size": 8,
+            "splitting_keys": [
+                "tokens",
+                "entity_types",
+                "entity_ids",
+                "mention_lengths"
+            ]
+        }
+    },
+    "model": {
+        "type": "entitynlm",
+        "dropout_rate": 0.4,
+        "embedding_dim": 10,
+        "encoder": {
+            "type": "lstm",
+            "dropout": 0.5,
+            "hidden_size": 10,
+            "input_size": 10,
+            "stateful": true
+        },
+        "max_embeddings": 20,
+        "max_mention_length": 20,
+        "text_field_embedder": {
+            "token_embedders": {
+                "tokens": {
+                    "type": "embedding",
+                    "embedding_dim": 10,
+                    "trainable": true
+                }
+            }
+        },
+        "tie_weights": true,
+        "variational_dropout_rate": 0.1
+    },
+    "train_data_path": "kglm/tests/fixtures/enhanced-wikitext.jsonl",
+    "validation_data_path": "kglm/tests/fixtures/enhanced-wikitext.jsonl",
+    "trainer": {
+        "cuda_device": -1,
+        "num_epochs": 2,
+        "optimizer": {
+            "type": "adam",
+            "lr": 0.0003
+        }
+    },
+    "vocabulary": {
+        "type": "extended",
+        "max_vocab_size": {
+            "tokens": 33278
+        },
+        "min_count": {
+            "tokens": 3
+        }
+    },
+    "datasets_for_vocab_creation": [
+        "train"
+    ]
+}

--- a/kglm/tests/models/entity_nlm_test.py
+++ b/kglm/tests/models/entity_nlm_test.py
@@ -1,0 +1,26 @@
+# pylint: disable=protected-access,not-callable,unused-import
+
+from allennlp.common.testing import ModelTestCase
+import numpy as np
+import torch
+
+from kglm.data.dataset_readers.enhanced_wikitext import EnhancedWikitextEntityNlmReader
+from kglm.models.entity_nlm import EntityNLM
+
+
+class EntityNLMTest(ModelTestCase):
+
+    def setUp(self):
+        super().setUp()
+        self.set_up_model("kglm/tests/fixtures/training_config/entity_nlm.json",
+                          "kglm/tests/fixtures/enhanced-wikitext.jsonl")
+
+    def test_model_can_train_save_and_load(self):
+        # TODO: Construct test cases where we can obtain gradients for these components
+        gradients_to_ignore = [
+                '_dummy_context_embedding',
+                '_dynamic_embeddings._distance_scalar',
+                '_dynamic_embeddings._embedding_projection.weight'
+        ]
+        self.ensure_model_can_train_save_and_load(self.param_file,
+                                                  gradients_to_ignore=gradients_to_ignore)

--- a/kglm/tests/models/kglm_test.py
+++ b/kglm/tests/models/kglm_test.py
@@ -16,7 +16,7 @@ class KglmTest(ModelTestCase):
                           "kglm/tests/fixtures/enhanced-wikitext.jsonl")
 
     def test_model_can_train_save_and_load(self):
-        # We ignore the copy mode projection weights since not every sequence will involve a copy
-        # operation.
+        # TODO: Construct a test case where we can ensure that _copy_mode_projection is learning
+        # something.
         self.ensure_model_can_train_save_and_load(self.param_file,
                                                   gradients_to_ignore=['_copy_mode_projection'])

--- a/kglm/training/metrics/__init__.py
+++ b/kglm/training/metrics/__init__.py
@@ -1,1 +1,1 @@
-from .perplexity import Perplexity, UnknownPenalizedPerplexity
+from .perplexity import Perplexity, UnknownPenalizedPerplexity, Ppl

--- a/kglm/training/metrics/perplexity.py
+++ b/kglm/training/metrics/perplexity.py
@@ -13,7 +13,7 @@ import torch.nn.functional as F
 from kglm.data.extended_vocabulary import ExtendedVocabulary
 
 
-@Metric.register('ppl')
+@Metric.register('ppl-old')
 class Perplexity(Metric):
     """Computes perplexity."""
     def __init__(self) -> None:
@@ -28,18 +28,18 @@ class Perplexity(Metric):
         Parameters
         ----------
         logits : ``torch.Tensor``, required.
-            A tensor of class logits of shape (batch_size, k, sequence_length).
+            A tensor of class logits of shape (batch_size, sequence_length, num_classes).
         labels : ``torch.Tensor``, required.
             A tensor of integer class labels of shape (batch_size, sequence_length).
         mask: ``torch.Tensor``, optional (default = None).
             A binary mask tensor of shape (batch_size, sequence_length).
         """
         logits, labels, mask = self.unwrap_to_tensors(logits, labels, mask)
-
-        log_p = -F.cross_entropy(logits, labels, reduction='none')
+        log_p = F.log_softmax(logits, dim=2)
+        log_p = torch.gather(log_p, dim=2, index=labels.unsqueeze(2)).squeeze(2)
         if mask is not None:
-            self._sum_log_p += (mask * log_p).sum()
-            self._total_count += mask.sum()
+            self._sum_log_p += (mask.float() * log_p).sum()
+            self._total_count += mask.float().sum()
         else:
             self._sum_log_p += log_p.sum()
             self._total_count += torch.numel(labels)  # pylint: disable=no-member
@@ -47,7 +47,7 @@ class Perplexity(Metric):
     @overrides
     def get_metric(self, reset: bool) -> float:
         cross_entropy = -self._sum_log_p / self._total_count
-        perplexity = math.exp(cross_entropy)
+        perplexity = cross_entropy.exp()
         if reset:
             self.reset()
         return perplexity
@@ -127,6 +127,32 @@ class UnknownPenalizedPerplexity(Metric):
         return perplexity
 
     @overrides
-    def reset(self):
+    def reset(self) -> None:
         self._sum_log_p = 0.0
         self._total_count = 0.0
+
+
+@Metric.register('ppl')
+class Ppl(Metric):
+
+    def __init__(self):
+        self.numerator = 0.0
+        self.denominator = 0.0
+
+    def __call__(self, numerator, denominator):
+        self.numerator += numerator
+        self.denominator += denominator
+
+    @overrides
+    def get_metric(self, reset: bool):
+        ratio = float(self.numerator) / (float(self.denominator) + 1e-13)
+        ppl = math.exp(ratio)
+        if reset:
+            self.reset()
+        return ppl
+
+    @overrides
+    def reset(self) -> None:
+        self.numerator = 0.0
+        self.denominator = 0.0
+

--- a/kglm/training/metrics/perplexity.py
+++ b/kglm/training/metrics/perplexity.py
@@ -1,6 +1,7 @@
 """
 Implementation of perplexity and unknown penalized perplexity metrics.
 """
+import logging
 import math
 from typing import Optional
 
@@ -11,6 +12,8 @@ import torch
 import torch.nn.functional as F
 
 from kglm.data.extended_vocabulary import ExtendedVocabulary
+
+logger = logging.getLogger(__name__)
 
 
 @Metric.register('ppl-old')
@@ -153,6 +156,7 @@ class Ppl(Metric):
 
     @overrides
     def reset(self) -> None:
+        logger.debug('Resetting Ppl')
         self.numerator = 0.0
         self.denominator = 0.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-git+git://github.com/rloganiv/allennlp.git@7b72c71a3a18eaf4f181b2d4a3f4a2552baa2e86
+git+git://github.com/rloganiv/allennlp.git@pytorch-grad-clip
 
 # Coverage reports
 pytest-cov


### PR DESCRIPTION
This PR deals with the issue I raised on Slack about how naively chopping batches (as is done by the ``SplitIterator``) results in a lot of empty padding sequences, thereby severely impacting PPL. In order to condense this padding, I added the ``FancyIterator`` (needs a better name) which essentially recognizes when a sequence has terminated and replaces it with a new sequence in the next split.

I wanted to give you a chance to read it over and comment on it before I merge it into `master`. Also, it currently doesn't work with `EntityNLM` since it requires being able to only reset the fraction of the hidden states corresponding to new sequences.