### PR TITLE
Added `KnowledgeGraphLookup` module

### DIFF
--- a/kglm/modules/__init__.py
+++ b/kglm/modules/__init__.py
@@ -1,5 +1,6 @@
 from .dynamic_embeddings import DynamicEmbedding
 from .embed_regularize import embedded_dropout
+from .knowledge_graph_lookup import KnowledgeGraphLookup
 from .locked_dropout import LockedDropout
 from .splitcross import SplitCrossEntropyLoss
 from .weight_drop import WeightDrop

--- a/kglm/modules/knowledge_graph_lookup.py
+++ b/kglm/modules/knowledge_graph_lookup.py
@@ -1,0 +1,96 @@
+import logging
+import pickle
+from typing import List, Tuple
+
+from allennlp.data.vocabulary import Vocabulary
+from tqdm import tqdm
+import torch
+
+from kglm.nn.util import nested_enumerate
+
+logger = logging.getLogger(__name__)
+
+
+class KnowledgeGraphLookup(object):
+    def __init__(self,
+                 kg_path: str,
+                 vocab: Vocabulary) -> None:
+        self._kg_path = kg_path
+        self._vocab = vocab
+        self._relations, self._tail_ids = self.load_kg(kg_path)
+
+    def load_kg(self, kg_path: str) -> Tuple[List[torch.LongTensor], List[torch.LongTensor]]:
+        logger.info('Loading knowledge graph from: %s', kg_path)
+        with open(kg_path, 'rb') as f:
+            knowledge_graph = pickle.load(f)
+
+        entity_idx_to_token = self._vocab.get_index_to_token_vocabulary('entity_ids')
+        all_relations: List[torch.Tensor] = []
+        all_tail_ids: List[torch.Tensor] = []
+        for i in tqdm(range(len(entity_idx_to_token))):
+            entity_id = entity_idx_to_token[i]
+            try:
+                # Get the relation and tail id tokens
+                relation_tokens, tail_id_tokens = zip(*knowledge_graph[entity_id])
+                # Index tokens
+                relations = [self._vocab.get_token_index(t, 'relations') for t in relation_tokens]
+                tail_ids = [self._vocab.get_token_index(t, 'entity_ids') for t in tail_id_tokens]
+                # Convert to tensors
+                relations = torch.LongTensor(relations)
+                tail_ids = torch.LongTensor(tail_ids)
+            except KeyError:
+                relations = torch.LongTensor([])
+                tail_ids = torch.LongTensor([])
+            all_relations.append(relations)
+            all_tail_ids.append(tail_ids)
+        return all_relations, all_tail_ids
+
+    def __call__(self,
+                 parent_ids: torch.LongTensor) -> torch.Tensor:
+        """Returns all relations of the form:
+
+            (parent_id, relation, tail_id)
+
+        from the knowledge graph.
+
+        Parameters
+        -----------
+        parent_ids : ``torch.LongTensor``
+            A tensor of arbitrary shape `(N, *)` where `*` means any number of additional
+            dimensions. Each element is an id in the knowledge graph.
+
+        Returns
+        -------
+        A tuple `(relations, tail_ids)` containing the following elements:
+        relations : ``torch.LongTensor``
+            A tensor of shape `(N, *, K)` corresponding to the input shape, with an
+            additional dimension whose size `K` is the largest number of relations to
+            a parent in the input. Each element is a relation id.
+        tail_ids : ``torch.LongTensor``
+            A tensor of shape `(N, *, K)` containing the corresponding tail ids.
+        """
+        # Collect the information to load into the output tensors.
+        K = 0
+        indices: List[Tuple[int, ...]] = []
+        relations_list: List[torch.LongTensor] = []
+        tail_ids_list: List[torch.LongTensor] = []
+        for *inds, parent_id in nested_enumerate(parent_ids):
+            # Retrieve data
+            relations = self._relations[parent_id]
+            tail_ids = self._tail_ids[parent_id]
+            # Update output size
+            K = max(K, len(relations))
+            # Add to lists
+            indices.append(inds)
+            relations_list.append(self._relations[parent_id])
+            tail_ids_list.append(self._tail_ids[parent_id])
+
+        # Construct the output tensors
+        relations = parent_ids.new_zeros(size=(*parent_ids.shape, K))
+        tail_ids = parent_ids.new_zeros(size=(*parent_ids.shape, K))
+        for inds, _relations, _tail_ids in zip(indices, relations_list, tail_ids_list):
+            index = (*inds, slice(None, len(_relations)))
+            relations[index] = _relations
+            tail_ids[index] = _tail_ids
+
+        return relations, tail_ids

--- a/kglm/nn/util.py
+++ b/kglm/nn/util.py
@@ -1,7 +1,7 @@
 from collections import Counter
 import gc
 import logging
-from typing import Tuple
+from typing import Any, Iterable, Iterator, Tuple
 
 import torch
 
@@ -57,3 +57,13 @@ def sample_from_logp(logp: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
     hack = torch.ones(logp.shape[:-1], device=logp.device, dtype=torch.uint8)
     selected_logp = logp[hack, selected_idx[hack]]
     return selected_logp, selected_idx
+
+
+def nested_enumerate(iterable):
+    try:
+        for i, element in enumerate(iterable):
+            for item in nested_enumerate(element):
+                combo = i, *item
+                yield combo
+    except TypeError:
+        yield (iterable,)

--- a/kglm/tests/modules/test_knowledge_graph_lookup.py
+++ b/kglm/tests/modules/test_knowledge_graph_lookup.py
@@ -1,0 +1,73 @@
+import pickle
+
+from allennlp.common.testing import AllenNlpTestCase
+from allennlp.data.vocabulary import Vocabulary
+import torch
+
+from kglm.modules import KnowledgeGraphLookup
+
+
+class KnowledgeGraphLookupTest(AllenNlpTestCase):
+    def setUp(self):
+        super().setUp()
+        # We assume our knowledge graphs are given in the form of pickled dictionaries, we'll
+        # create a simple one here for testing purposes.
+        self.temp_knowledge_graph = {
+            'E1': [['R1', 'E2'], ['R2', 'E3']],
+            'E2': [['R1', 'E3']],
+        }
+        self.path = self.TEST_DIR / 'relation.pkl'
+        with open(self.path, 'wb') as f:
+            pickle.dump(self.temp_knowledge_graph, f)
+
+        # We need a vocab to track the unique entity ids and relations
+        self.vocab = Vocabulary()
+        self.vocab.add_token_to_namespace('E1', 'entity_ids')
+        self.vocab.add_token_to_namespace('E2', 'entity_ids')
+        self.vocab.add_token_to_namespace('E3', 'entity_ids')
+        self.vocab.add_token_to_namespace('R1', 'relations')
+        self.vocab.add_token_to_namespace('R2', 'relations')
+
+        # Lastly we create the knowledge graph lookup
+        self.knowledge_graph_lookup = KnowledgeGraphLookup(self.path, self.vocab)
+
+    def test_lists_are_correct(self):
+        # The lookup converts the data in the knowledge graph into lists of tensors.
+        # Here we check that these lists contain the expected information.
+        relations = self.knowledge_graph_lookup._relations
+        tail_ids = self.knowledge_graph_lookup._tail_ids
+
+        # We'll check that the information is correct for entity 'E1'. We'll start by building the
+        # expected tensors from our inputs...
+        expected_relations, expected_tail_ids = zip(*self.temp_knowledge_graph['E1'])
+        expected_relations = [self.vocab.get_token_index(t, 'relations') for t in expected_relations]
+        expected_tail_ids = [self.vocab.get_token_index(t, 'entity_ids') for t in expected_tail_ids]
+        expected_relations = torch.LongTensor(expected_relations)
+        expected_tail_ids = torch.LongTensor(expected_tail_ids)
+        # ...then checking whether the corresponding elements in the lists are correct.
+        index = self.vocab.get_token_index('E1', 'entity_ids')
+        assert relations[index].equal(expected_relations)
+        assert tail_ids[index].equal(expected_tail_ids)
+
+    def test_lookup(self):
+        # Check that the output of the lookup matches our expectations.
+        parent_ids = [
+            self.vocab.get_token_index('E1', 'entity_ids'),
+            self.vocab.get_token_index('E2', 'entity_ids'),
+            self.vocab.get_token_index('E3', 'entity_ids')  # Should work, even though E3 not in the KG
+        ]
+        parent_ids = torch.LongTensor(parent_ids)
+        relations, tail_ids = self.knowledge_graph_lookup(parent_ids)
+
+        # Lookup indices of tokens expected to be in the output
+        e2 = self.vocab.get_token_index('E2', 'entity_ids')
+        e3 = self.vocab.get_token_index('E3', 'entity_ids')
+        r1 = self.vocab.get_token_index('R1', 'relations')
+        r2 = self.vocab.get_token_index('R2', 'relations')
+
+        # Expected outputs (these are directly transcribed from the KG)
+        expected_relations = torch.LongTensor([[r1, r2], [r1, 0], [0, 0]])
+        expected_tail_ids = torch.LongTensor([[e2, e3], [e3, 0], [0, 0]])
+
+        assert relations.equal(expected_relations)
+        assert tail_ids.equal(expected_tail_ids)


### PR DESCRIPTION
This module loads a knowledge graph (stored in the form of a pickled
dictionary whose keys are parent entity ids and whose values are lists
of (relation, tail id) tuples) into tensors.

Calling the module on a sequence of parent ids returns a pair of tensors
of the corresponding relation ids and tail ids.